### PR TITLE
Fix GPT futures analyze endpoint path

### DIFF
--- a/auto-analisa-web/backend/app/routers/gpt_analyze.py
+++ b/auto-analisa-web/backend/app/routers/gpt_analyze.py
@@ -20,7 +20,7 @@ class AnalyzeBody(BaseModel):
     opts: Optional[Dict[str, Any]] = None
 
 
-router = APIRouter(prefix="/gpt/futures", tags=["gpt-futures"])
+router = APIRouter(prefix="/api/gpt/futures", tags=["gpt-futures"])
 
 
 @router.post("/analyze")


### PR DESCRIPTION
## Summary
- sesuaikan prefix router GPT futures agar sesuai pola /api sehingga permintaan dari frontend tidak lagi berujung 404

## Testing
- pytest -q tests/test_strategy_futures.py

------
https://chatgpt.com/codex/tasks/task_e_68cea8fb49a4832891ce9f2e4cf01804