### PR TITLE
Patch Seri M: persistensi laporan GPT futures dan integrasi UI

### DIFF
--- a/auto-analisa-web/backend/app/auth.py
+++ b/auto-analisa-web/backend/app/auth.py
@@ -70,5 +70,11 @@ async def require_user(req: Request, db: AsyncSession = Depends(get_db)) -> User
     Admin endpoints should still use strict checks (e.g., require_admin).
     """
     if not settings.REQUIRE_LOGIN:
+        try:
+            token = get_token_from_request(req)
+            if token:
+                return await get_current_user(req, db)
+        except HTTPException:
+            pass
         return _PublicUser()  # type: ignore[return-value]
     return await get_current_user(req, db)

--- a/auto-analisa-web/backend/app/migrations/versions/202403150001_add_gpt_reports.py
+++ b/auto-analisa-web/backend/app/migrations/versions/202403150001_add_gpt_reports.py
@@ -1,0 +1,41 @@
+"""add gpt_reports"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "202403150001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "gpt_reports",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("symbol", sa.String(32), nullable=False, index=True),
+        sa.Column(
+            "mode",
+            sa.String(16),
+            nullable=False,
+            server_default=sa.text("'scalping'"),
+            index=True,
+        ),
+        sa.Column("text", sa.JSON, server_default=sa.text("'{}'")),
+        sa.Column("overlay", sa.JSON, server_default=sa.text("'{}'")),
+        sa.Column("meta", sa.JSON, server_default=sa.text("'{}'")),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("ttl", sa.Integer, nullable=False, server_default=sa.text("2700")),
+    )
+    op.create_index(
+        "ix_gpt_reports_symbol_mode_created",
+        "gpt_reports",
+        ["symbol", "mode", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_gpt_reports_symbol_mode_created", table_name="gpt_reports")
+    op.drop_table("gpt_reports")

--- a/auto-analisa-web/backend/app/models.py
+++ b/auto-analisa-web/backend/app/models.py
@@ -181,6 +181,21 @@ class LLMUsage(Base):
     updated_at: Mapped[dt.datetime | None] = mapped_column(DateTime, default=None)
 
 
+# Cached GPT futures reports untuk persistensi Patch Seri M
+class GPTReport(Base):
+    __tablename__ = "gpt_reports"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    symbol: Mapped[str] = mapped_column(String(32), index=True)
+    mode: Mapped[str] = mapped_column(String(16), default="scalping", index=True)
+    text: Mapped[dict] = mapped_column(JSON, default=dict)
+    overlay: Mapped[dict] = mapped_column(JSON, default=dict)
+    meta: Mapped[dict] = mapped_column(JSON, default=dict)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime, default=lambda: dt.datetime.now(dt.timezone.utc)
+    )
+    ttl: Mapped[int] = mapped_column(Integer, default=2700)
+
+
 # Futures metadata and signals cache (skeleton for Futures module)
 class FuturesMeta(Base):
     __tablename__ = "futures_meta"

--- a/auto-analisa-web/backend/app/tests/test_gpt_reports.py
+++ b/auto-analisa-web/backend/app/tests/test_gpt_reports.py
@@ -1,0 +1,105 @@
+import os
+import datetime as dt
+import pytest
+import httpx
+
+from app.main import app
+from app.config import settings
+from app.models import GPTReport
+from app.storage.db import SessionLocal
+
+
+@pytest.mark.asyncio
+async def test_gpt_analyze_persist_and_fetch(monkeypatch):
+    settings.REQUIRE_LOGIN = False
+    os.environ["OPENAI_API_KEY"] = "test-key"
+
+    async def _should_use_llm(db):
+        return True, None
+
+    async def _get_today_usage(db, user_id, kind, limit_override=None):
+        return {"remaining": 5}
+
+    async def _inc_usage(db, **kwargs):
+        return None
+
+    class _Settings:
+        llm_daily_limit_futures = 40
+
+    async def _get_or_init_settings(db):
+        return _Settings()
+
+    def _call_gpt(prompt):
+        return (
+            {
+                "text": {
+                    "section_scalping": {
+                        "posisi": "LONG",
+                        "tp": [1.1, 1.2, 1.3],
+                        "sl": 0.9,
+                        "strategi_singkat": ["Entry di support"],
+                        "fundamental": ["BTC kuat"],
+                    }
+                },
+                "overlay": {
+                    "tf": "15m",
+                    "lines": [
+                        {"type": "TP", "label": "TP1", "price": 1.1},
+                        {"type": "SL", "label": "SL", "price": 0.9},
+                    ],
+                    "zones": [],
+                },
+                "meta": {"engine": "unit-test"},
+            },
+            {"prompt_tokens": 10, "completion_tokens": 5},
+        )
+
+    monkeypatch.setattr("app.routers.gpt_analyze.should_use_llm", _should_use_llm)
+    monkeypatch.setattr("app.routers.gpt_analyze.get_today_usage", _get_today_usage)
+    monkeypatch.setattr("app.routers.gpt_analyze.inc_usage", _inc_usage)
+    monkeypatch.setattr("app.routers.gpt_analyze.get_or_init_settings", _get_or_init_settings)
+    monkeypatch.setattr("app.routers.gpt_analyze.call_gpt", _call_gpt)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/gpt/futures/analyze",
+            json={"symbol": "btcusdt", "mode": "scalping", "payload": {}, "opts": {}},
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["report_id"] > 0
+        assert payload["meta"]["engine"] == "unit-test"
+        created_at = dt.datetime.fromisoformat(payload["created_at"])
+        assert created_at.tzinfo is not None
+
+        # Ensure tersimpan di DB
+        async with SessionLocal() as session:
+            row = await session.get(GPTReport, payload["report_id"])
+            assert row is not None
+            assert row.symbol == "BTCUSDT"
+            assert row.mode == "scalping"
+            assert row.text["section_scalping"]["posisi"] == "LONG"
+
+        # GET cache sukses
+        r2 = await client.get("/api/gpt/futures/report", params={"symbol": "BTCUSDT", "mode": "scalping"})
+        assert r2.status_code == 200
+        data = r2.json()
+        assert data["report_id"] == payload["report_id"]
+        assert data["text"]["section_scalping"]["posisi"] == "LONG"
+        assert data["ttl"] == payload["ttl"]
+
+        # nocache memaksa 404
+        r3 = await client.get(
+            "/api/gpt/futures/report",
+            params={"symbol": "BTCUSDT", "mode": "scalping", "nocache": 1},
+        )
+        assert r3.status_code == 404
+
+        # manipulasi TTL -> expired
+        async with SessionLocal() as session:
+            row = await session.get(GPTReport, payload["report_id"])
+            row.created_at = (row.created_at or dt.datetime.now(dt.timezone.utc)) - dt.timedelta(hours=2)
+            await session.commit()
+
+        r4 = await client.get("/api/gpt/futures/report", params={"symbol": "BTCUSDT", "mode": "scalping"})
+        assert r4.status_code == 404

--- a/auto-analisa-web/frontend/src/app/(components)/FuturesWatchlist.tsx
+++ b/auto-analisa-web/frontend/src/app/(components)/FuturesWatchlist.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Plus, X } from "lucide-react"
+import { api } from "../api"
+
+type QuotaInfo = { limit: number; remaining: number; llm_enabled?: boolean }
+
+type Props = {
+  onSelect: (symbol: string) => void
+  selectedSymbol?: string | null
+  quota?: QuotaInfo | null
+  onReady?: (items: string[]) => void
+}
+
+export default function FuturesWatchlist({ onSelect, selectedSymbol, quota, onReady }: Props) {
+  const [items, setItems] = useState<string[]>([])
+  const [input, setInput] = useState("")
+  const [msg, setMsg] = useState<string>("")
+
+  async function load() {
+    try {
+      const r = await api.get("watchlist", { params: { trade_type: "futures" } })
+      const list: string[] = r.data || []
+      setItems(list)
+      onReady?.(list)
+      setMsg("")
+    } catch (e: any) {
+      setMsg(e?.response?.data?.detail || "Gagal memuat watchlist")
+    }
+  }
+
+  async function add() {
+    if (!input) return
+    if (items.length >= 4) {
+      setMsg("Maksimal 4 simbol dalam watchlist.")
+      return
+    }
+    try {
+      const symbol = input.trim().toUpperCase()
+      await api.post("watchlist/add", null, { params: { symbol, trade_type: "futures" } })
+      setInput("")
+      setMsg("")
+      await load()
+      onSelect(symbol)
+    } catch (e: any) {
+      setMsg(e?.response?.data?.detail || "Gagal menambah simbol")
+    }
+  }
+
+  async function remove(symbol: string) {
+    try {
+      await api.delete(`watchlist/${encodeURIComponent(symbol)}`, { params: { trade_type: "futures" } })
+      setItems((prev) => {
+        const next = prev.filter((s) => s !== symbol)
+        if (selectedSymbol && selectedSymbol.toUpperCase() === symbol.toUpperCase()) {
+          const fallback = next[0] || ""
+          onSelect(fallback)
+        }
+        onReady?.(next)
+        return next
+      })
+    } catch (e: any) {
+      setMsg(e?.response?.data?.detail || "Gagal menghapus simbol")
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  return (
+    <section className="rounded-2xl ring-1 ring-zinc-200 dark:ring-white/10 bg-white dark:bg-zinc-900 p-4 text-zinc-900 dark:text-zinc-100">
+      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+        <div className="flex-1 space-y-2">
+          <h3 className="font-semibold text-base">Watchlist Futures</h3>
+          <div className="flex items-center gap-2">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value.toUpperCase())}
+              placeholder="IMXUSDT"
+              className="rounded px-3 py-2 w-full bg-white text-zinc-900 ring-1 ring-inset ring-zinc-200 focus:outline-none focus:ring-2 focus:ring-cyan-500 dark:bg-transparent dark:text-white placeholder:text-zinc-400 dark:ring-white/10"
+            />
+            <button
+              onClick={add}
+              className="inline-flex items-center gap-1 px-3 py-2 rounded bg-cyan-600 text-white hover:bg-cyan-500 disabled:opacity-50"
+              disabled={items.length >= 4}
+            >
+              <Plus size={16} /> Tambah
+            </button>
+            {quota && (
+              <span
+                className={`px-2 py-1 rounded text-xs ${quota.remaining > 0 ? "bg-emerald-600" : "bg-rose-600"} text-white`}
+                title={quota.llm_enabled ? "LLM aktif" : "LLM nonaktif"}
+              >
+                LLM {quota.remaining}/{quota.limit}
+              </span>
+            )}
+          </div>
+          {msg && <div className="text-xs text-rose-500">{msg}</div>}
+        </div>
+        <div className="flex-1">
+          <h4 className="text-sm font-medium mb-1">Simbol</h4>
+          <div className="flex flex-wrap gap-2">
+            {items.map((s) => (
+              <div
+                key={s}
+                className={`inline-flex items-center gap-2 px-3 py-1 rounded-full border ${
+                  selectedSymbol && selectedSymbol.toUpperCase() === s
+                    ? "bg-indigo-600 border-indigo-600 text-white"
+                    : "bg-zinc-100 border-zinc-200 dark:bg-zinc-800 dark:border-zinc-700 text-zinc-800 dark:text-zinc-100"
+                }`}
+              >
+                <button onClick={() => onSelect(s)} className="font-medium">
+                  {s}
+                </button>
+                <button onClick={() => remove(s)} className="text-rose-600 hover:text-rose-700">
+                  <X size={14} />
+                </button>
+              </div>
+            ))}
+            {items.length === 0 && <div className="text-xs text-zinc-500">Tambah simbol untuk mulai menganalisa.</div>}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/auto-analisa-web/frontend/src/app/futures/page.tsx
+++ b/auto-analisa-web/frontend/src/app/futures/page.tsx
@@ -1,97 +1,112 @@
 "use client"
-import {useEffect, useState} from 'react'
-import Link from 'next/link'
-import { api } from '../api'
-import WatchlistRow from '../(components)/WatchlistRow'
-import FuturesCard from '../(components)/FuturesCard'
+import { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { api } from "../api"
+import FuturesWatchlist from "../(components)/FuturesWatchlist"
+import FuturesCard from "../(components)/FuturesCard"
 
-export default function FuturesPage(){
-  const [cards,setCards]=useState<any[]>([])
-  const [loggedIn,setLoggedIn]=useState(false)
-  const [quota,setQuota]=useState<{limit:number, remaining:number, calls?:number, llm_enabled:boolean, futures_limit?:number, futures_remaining?:number}|null>(null)
+type Quota = {
+  limit: number
+  remaining: number
+  calls?: number
+  llm_enabled?: boolean
+  futures_limit?: number
+  futures_remaining?: number
+}
 
-  useEffect(()=>{
-    if(typeof window!=='undefined'){
-      const isLogged = !!(localStorage.getItem('token') || localStorage.getItem('access_token'))
-      setLoggedIn(isLogged)
-      if (isLogged) { load(); loadQuota() } else { setCards([]); setQuota(null) }
+const LOCAL_SELECTED_KEY = "futures:selected-symbol"
+
+export default function FuturesPage() {
+  const [selectedSymbol, setSelectedSymbol] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null
+    return localStorage.getItem(LOCAL_SELECTED_KEY)
+  })
+  const [loggedIn, setLoggedIn] = useState(false)
+  const [quota, setQuota] = useState<Quota | null>(null)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const token = localStorage.getItem("token") || localStorage.getItem("access_token")
+    const isLogged = !!token
+    setLoggedIn(isLogged)
+    if (isLogged) {
+      loadQuota()
+    } else {
+      setQuota(null)
     }
-  },[])
+  }, [])
 
-  async function loadQuota(){
-    try{
-      const r = await api.get('llm/quota')
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (selectedSymbol) localStorage.setItem(LOCAL_SELECTED_KEY, selectedSymbol)
+    else localStorage.removeItem(LOCAL_SELECTED_KEY)
+  }, [selectedSymbol])
+
+  async function loadQuota() {
+    try {
+      const r = await api.get("llm/quota")
       setQuota(r.data)
-    }catch{ setQuota(null) }
-  }
-  async function load(){
-    try{
-      const r = await api.get('analyses', { params:{ status: 'active', trade_type: 'futures' } })
-      setCards(r.data)
-    }catch{}
-  }
-  async function analyze(symbol:string){
-    if(cards.length>=4){ alert('Maksimal 4 analisa aktif. Arsipkan salah satu dulu.'); return }
-    try{
-      const {data}=await api.post('analyze',{symbol, trade_type: 'futures'})
-      setCards(prev=>{
-        const next=[data, ...prev]
-        const seen = new Set<string>()
-        const uniq: any[] = []
-        for (const it of next){
-          const key = `${it.symbol}:${it.trade_type||'futures'}`
-          if(!seen.has(key)){ uniq.push(it); seen.add(key) }
-        }
-        return uniq.slice(0,4)
-      })
-    }catch(e:any){
-      if(e?.response?.status===409) alert(e.response.data?.detail||'Maksimum 4 analisa aktif per user.')
-      else alert('Gagal menganalisa')
-    }
-  }
-  async function updateOne(idx:number){
-    const c=cards[idx]
-    try{
-      const {data}=await api.post(`analyses/${c.id}/refresh`)
-      const updated = data?.analysis
-      if(updated){
-        const cp=[...cards]; cp[idx]=updated; setCards(cp)
-      }
-    }catch(e:any){
-      if(e?.response?.status===429) alert('Terlalu sering, coba lagi sebentar.')
-      else alert('Gagal update analisa')
+    } catch {
+      setQuota(null)
     }
   }
 
-  const futRemaining = (quota?.futures_remaining ?? quota?.remaining ?? 0)
-  const futLimit = (quota?.futures_limit ?? quota?.limit ?? 0)
+  const futRemaining = useMemo(() => quota?.futures_remaining ?? quota?.remaining ?? 0, [quota])
+  const futLimit = useMemo(() => quota?.futures_limit ?? quota?.limit ?? 0, [quota])
 
   return (
     <main className="space-y-4">
       <div className="max-w-7xl mx-auto px-4 md:px-6 pt-6">
         <div className="flex items-center justify-between">
           <h1 className="text-xl font-semibold">Analisa Futures</h1>
-          <Link href="/" className="text-sm underline">← Kembali ke Spot</Link>
+          <Link href="/" className="text-sm underline">
+            ← Kembali ke Spot
+          </Link>
         </div>
-        <p className="mt-1 text-sm text-zinc-600">Halaman ini terpisah dari Spot. Setiap simbol dianalisa dalam konteks Futures.</p>
+        <p className="mt-1 text-sm text-zinc-600">
+          Klik simbol atau gunakan Tanya GPT untuk memunculkan analisa lengkap dengan overlay.
+        </p>
       </div>
       <div id="analisa" className="max-w-7xl mx-auto px-4 md:px-6 space-y-4">
         {loggedIn ? (
-          <WatchlistRow tradeType='futures' quota={{ limit: futLimit, remaining: futRemaining, llm_enabled: !!quota?.llm_enabled }} onPick={(s)=>analyze(s)} titleLabel="Analisa Futures" onDelete={(s)=>{ setCards(prev=> prev.filter(c=> c.symbol !== s)) }} />
+          <>
+            <FuturesWatchlist
+              quota={{ limit: futLimit, remaining: futRemaining, llm_enabled: !!quota?.llm_enabled }}
+              selectedSymbol={selectedSymbol}
+              onSelect={(s) => setSelectedSymbol(s || null)}
+              onReady={(items) => {
+                if (!selectedSymbol && items && items.length > 0) {
+                  setSelectedSymbol(items[0])
+                }
+              }}
+            />
+            {quota && (
+              <div className="mt-1 text-xs opacity-60">
+                Kuota LLM Futures: {futRemaining}/{futLimit}
+              </div>
+            )}
+            {selectedSymbol ? (
+              <FuturesCard
+                key={selectedSymbol}
+                symbol={selectedSymbol}
+                llmEnabled={!!quota?.llm_enabled}
+                llmRemaining={typeof futRemaining === "number" ? futRemaining : undefined}
+                onRefreshQuota={loadQuota}
+              />
+            ) : (
+              <div className="rounded-2xl ring-1 ring-zinc-200 dark:ring-white/10 bg-white dark:bg-zinc-900 p-6 text-sm text-zinc-500">
+                Pilih simbol dari watchlist untuk memuat analisa Futures.
+              </div>
+            )}
+          </>
         ) : (
-          <div className="rounded-2xl ring-1 ring-zinc-200 dark:ring-white/10 bg-white dark:bg-zinc-900 p-4 text-sm text-gray-600">Login untuk mengelola watchlist dan menganalisa.</div>
-        )}
-        {quota && (typeof futRemaining==='number') && (
-          <div className="mt-1 text-xs opacity-60">LLM futures quota: {futRemaining}/{futLimit}</div>
-        )}
-        <div>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {cards.map((c,idx)=> (
-              <FuturesCard key={c.id} plan={c} onUpdate={()=>updateOne(idx)} llmEnabled={!!quota?.llm_enabled} llmRemaining={futRemaining} onAfterVerify={loadQuota} />
-            ))}
+          <div className="rounded-2xl ring-1 ring-zinc-200 dark:ring-white/10 bg-white dark:bg-zinc-900 p-4 text-sm text-gray-600">
+            Login untuk mengelola watchlist dan menganalisa.
           </div>
+        )}
+        <div className="mt-6 text-xs opacity-60">
+          Aturan: Edukasi, bukan saran finansial. Rate-limit aktif. Hasil per user terpisah.
         </div>
-        <div className="mt-6 text-xs opacity-60">Aturan: Edukasi, bukan saran finansial. Rate-limit aktif. Hasil per user terpisah.</div>
       </div>
     </main>
   )


### PR DESCRIPTION
## Ringkasan
- Menambahkan model `GPTReport`, endpoint cache `/api/gpt/futures/report`, serta penyimpanan otomatis ketika memanggil `/api/gpt/futures/analyze`.
- Menambah halaman futures baru yang memuat watchlist khusus, kartu analisa dengan tab TF 5m/15m/1h/4h, tombol Tanya GPT per mode, serta overlay chart lengkap sesuai jawaban GPT.
- Menambahkan komponen `GptReportBox` untuk menampilkan laporan GPT terformat, menyesuaikan panel metrik ungu agar menggunakan SL/TP dari overlay, dan menerapkan tombol "Terapkan Saran" ke rencana trading.
- Menghadirkan dukungan overlay LLM (garis TP/SL, zona ENTRY/BYBK, marker BO) di `ChartOHLCV` dan mekanisme cache lokal + backend sehingga hasil GPT bertahan ketika halaman di-refresh.
- Memperkuat cache verifikasi LLM spot agar menyertakan `spot2_json`, mengabaikan cache ketika analisa sudah diperbarui, serta memastikan `require_user` tetap memulangkan user asli ketika token tersedia meski login tidak diwajibkan.

## Pengujian
- `pytest -q`
- `npm install`
- `npm run lint` *(gagal karena script tidak tersedia)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4793eb6483288f407ec2b4169d9e