### PR TITLE
feat(spot): perbarui planner SPOT-II+ dengan integrasi makro

### DIFF
--- a/auto-analisa-web/backend/app/services/strategies_spot.py
+++ b/auto-analisa-web/backend/app/services/strategies_spot.py
@@ -1,9 +1,53 @@
 from __future__ import annotations
-from typing import Dict
+from typing import Dict, List, Tuple
+import math
 
 
 def _buf(price: float, atr15: float) -> float:
     return max(float(atr15) * 0.20, abs(float(price)) * 1e-4)
+
+
+def _tp_ladder(
+    price: float,
+    atr: float,
+    resistances: List[float],
+    swing_highs: Tuple[float, float, float] | None = None,
+) -> Tuple[List[float], List[str]]:
+    """Bangun 3 target TP default (static ladder + ATR + swing mapping)."""
+
+    r1 = float(resistances[0]) if resistances else price + atr
+    r2 = float(resistances[1]) if len(resistances) > 1 else r1 + atr
+    r3 = float(resistances[2]) if len(resistances) > 2 else r2 + atr * 1.2
+
+    base_tp1 = min(r1, price + atr * 1.05)
+    base_tp2 = max(r2, base_tp1 + atr * 0.75)
+    base_tp3 = max(r3, base_tp2 + atr * 0.9)
+
+    if swing_highs:
+        sh1, sh2, sh3 = swing_highs
+        base_tp1 = max(min(base_tp1, sh1), price + atr * 0.6)
+        base_tp2 = max(base_tp2, sh2)
+        base_tp3 = max(base_tp3, sh3)
+
+    def _round_ext(val: float) -> float:
+        if val <= 0:
+            return float(val)
+        magnitude = 10 ** math.floor(math.log10(abs(val)))
+        step = magnitude / 20
+        if step == 0:
+            return float(val)
+        return math.ceil(val / step) * step
+
+    tp1 = float(base_tp1)
+    tp2 = float(base_tp2)
+    tp3 = float(_round_ext(base_tp3))
+
+    logic = [
+        "Ambil profit cepat / minor R",
+        "Target utama / resist 1H",
+        "Ekstensi / round number",
+    ]
+    return [tp1, tp2, tp3], logic
 
 
 def plan_pb(bundle, levels: Dict) -> Dict:
@@ -11,21 +55,26 @@ def plan_pb(bundle, levels: Dict) -> Dict:
     p = float(getattr(last, "close"))
     a = float(getattr(last, "atr14", 0.0))
     s1, s2 = levels["support"][:2]
-    r1, r2 = levels["resistance"][:2]
+    r = levels["resistance"]
     e1 = max(s1, p - a * 0.6)
     e2 = max(s2, p - a * 1.2)
     invalid = min(e1, e2) - _buf(p, a)
-    tp1 = r1
-    tp2 = max(r1 + (r1 - p) * 0.6, r2)
+    swings = tuple(levels.get("swing_highs", [])[:3]) or None
+    tp_vals, tp_logic = _tp_ladder(p, a, r, swings if swings and len(swings) >= 3 else None)
     return {
         "mode": "PB",
         "bias": f"Pullback buy di atas {s1:.6f}",
-        "support": [s1, s2],
-        "resistance": [r1, r2],
+        "support": levels["support"],
+        "resistance": r,
         "entries": [e1, e2],
         "weights": [0.4, 0.6],
         "invalid": invalid,
-        "tp": [tp1, tp2],
+        "tp": tp_vals,
+        "tp_logic": tp_logic,
+        "entry_notes": [
+            "Entry inti di retest EMA20/VWAP",
+            "Tambah di support lanjutan / EMA50",
+        ],
     }
 
 
@@ -34,17 +83,26 @@ def plan_bo(bundle, levels: Dict) -> Dict:
     p = float(getattr(last, "close"))
     a = float(getattr(last, "atr14", 0.0))
     r1 = levels["resistance"][0]
-    e = max(r1, p + a * 0.2)
-    invalid = e - a * 1.0
+    r = levels["resistance"]
+    trigger = max(r1, p + a * 0.25)
+    retest = trigger - max(a * 0.35, abs(trigger) * 1e-4)
+    invalid = retest - a * 0.9
+    swings = tuple(levels.get("swing_highs", [])[:3]) or None
+    tp_vals, tp_logic = _tp_ladder(trigger, a, r, swings if swings and len(swings) >= 3 else None)
     return {
         "mode": "BO",
         "bias": "Breakout buy di atas range ketat",
         "support": levels["support"],
-        "resistance": levels["resistance"],
-        "entries": [e],
-        "weights": [1.0],
+        "resistance": r,
+        "entries": [trigger, retest],
+        "weights": [0.5, 0.5],
         "invalid": invalid,
-        "tp": [e + a * 1.2, e + a * 2.0],
+        "tp": tp_vals,
+        "tp_logic": tp_logic,
+        "entry_notes": [
+            "Stop-limit di atas high range",
+            "Re-add saat retest VWAP/R1",
+        ],
     }
 
 
@@ -56,15 +114,22 @@ def plan_rr(bundle, levels: Dict) -> Dict:
     e1 = s1
     e2 = s2
     invalid = min(e1, e2) - _buf(p, a)
+    swings = tuple(levels.get("swing_highs", [])[:3]) or None
+    tp_vals, tp_logic = _tp_ladder(p, a, levels["resistance"], swings if swings and len(swings) >= 3 else None)
     return {
         "mode": "RR",
         "bias": "Range reversal dari lower band/demand",
-        "support": [s1, s2],
+        "support": levels["support"],
         "resistance": levels["resistance"],
         "entries": [e1, e2],
-        "weights": [0.5, 0.5],
+        "weights": [0.45, 0.55],
         "invalid": invalid,
-        "tp": [levels["resistance"][0], levels["resistance"][1]],
+        "tp": tp_vals,
+        "tp_logic": tp_logic,
+        "entry_notes": [
+            "Beli di VWAP-low range",
+            "Tambah di demand bawah / EMA100",
+        ],
     }
 
 
@@ -73,9 +138,11 @@ def plan_sr(bundle, levels: Dict) -> Dict:
     p = float(getattr(last, "close"))
     a = float(getattr(last, "atr14", 0.0))
     s1 = levels["support"][0]
-    e1 = s1  # beli setelah reclaim di atas s1 (konfirmasi mesti ditangani di upstream signal)
+    e1 = s1
     e2 = max(levels["support"][1], p - a)
     invalid = min(e1, e2) - _buf(p, a)
+    swings = tuple(levels.get("swing_highs", [])[:3]) or None
+    tp_vals, tp_logic = _tp_ladder(p, a, levels["resistance"], swings if swings and len(swings) >= 3 else None)
     return {
         "mode": "SR",
         "bias": "Sweep & reclaim dari support kunci",
@@ -84,7 +151,12 @@ def plan_sr(bundle, levels: Dict) -> Dict:
         "entries": [e1, e2],
         "weights": [0.4, 0.6],
         "invalid": invalid,
-        "tp": [levels["resistance"][0], levels["resistance"][1]],
+        "tp": tp_vals,
+        "tp_logic": tp_logic,
+        "entry_notes": [
+            "Entry setelah reclaim support",
+            "Tambah di pullback ke EMA50",
+        ],
     }
 
 
@@ -100,15 +172,22 @@ def plan_ff(bundle, levels: Dict, fvg=None) -> Dict:
         e1 = p - a * 0.5
         e2 = p - a * 1.0
     invalid = min(e1, e2) - _buf(p, a)
+    swings = tuple(levels.get("swing_highs", [])[:3]) or None
+    tp_vals, tp_logic = _tp_ladder(p, a, levels["resistance"], swings if swings and len(swings) >= 3 else None)
     return {
         "mode": "FF",
         "bias": "Fair Value Gap fill buy",
         "support": levels["support"],
         "resistance": levels["resistance"],
         "entries": [e1, e2],
-        "weights": [0.5, 0.5],
+        "weights": [0.45, 0.55],
         "invalid": invalid,
-        "tp": [levels["resistance"][0], levels["resistance"][1]],
+        "tp": tp_vals,
+        "tp_logic": tp_logic,
+        "entry_notes": [
+            "Isi FVG tengah",
+            "Isi FVG bawah / demand kuat",
+        ],
     }
 
 

--- a/auto-analisa-web/backend/app/tests/test_analysis_limits.py
+++ b/auto-analisa-web/backend/app/tests/test_analysis_limits.py
@@ -30,8 +30,8 @@ async def test_run_analysis_limits_per_trade_type(monkeypatch):
     async def fake_build_plan_async(db, bundle, feat, score, mode):
         return {"entries": [], "tp": [], "invalid": None}
 
-    async def fake_build_spot2_from_plan(db, sym, plan):
-        return {"rencana_jual_beli": {}, "tp": []}
+    async def fake_build_spot2_from_plan(db, sym, plan, bundle=None):
+        return {"entries": [], "tp": [], "invalids": {}}
 
     def fake_round_plan_prices(sym, plan):
         return plan

--- a/auto-analisa-web/backend/app/tests/test_llm_parser.py
+++ b/auto-analisa-web/backend/app/tests/test_llm_parser.py
@@ -40,20 +40,27 @@ async def test_verify_llm_accepts_string_numbers_and_rounds(monkeypatch):
 
     # ask_llm returns SPOT II style with strings for numbers
     payload = {
-        "rencana_jual_beli": {
-            "entries": [
-                {"range": ["100.001", "100.001"], "weight": 0.6},
-                {"range": ["98.339", "98.339"], "weight": 0.4},
-            ],
-            "invalid": "95.001",
-        },
-        "tp": [
-            {"name": "TP1", "range": ["110.004", "110.004"]},
-            {"name": "TP2", "range": ["115.008", "115.008"]},
+        "entries": [
+            {"price": "100.001", "weight": "0.6", "type": "PB"},
+            {"price": "98.339", "weight": "0.4", "type": "PB"},
         ],
+        "invalid": "95.001",
+        "tp": [
+            {"name": "TP1", "price": "110.004", "qty_pct": "30", "logic": "Minor R"},
+            {"name": "TP2", "price": "115.008", "qty_pct": "40", "logic": "Major R"},
+        ],
+        "macro_gate": {"avoid_red": True, "prefer_wib": ["19:30-22:00"]},
     }
     import json
-    monkeypatch.setattr(r_analyses, "ask_llm", lambda prompt: (json.dumps(payload), {"prompt_tokens": 10, "completion_tokens": 20}), raising=True)
+    calls = [
+        (json.dumps(payload), {"prompt_tokens": 10, "completion_tokens": 20}),
+        (json.dumps({"verdict": "confirm", "reasons": [], "summary": "OK"}), {"prompt_tokens": 5, "completion_tokens": 3}),
+    ]
+    def fake_ask(prompt):
+        if not calls:
+            return (json.dumps({"verdict": "confirm", "reasons": []}), {"prompt_tokens": 0, "completion_tokens": 0})
+        return calls.pop(0)
+    monkeypatch.setattr(r_analyses, "ask_llm", fake_ask, raising=True)
 
     async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
         # Auth
@@ -73,8 +80,8 @@ async def test_verify_llm_accepts_string_numbers_and_rounds(monkeypatch):
         # spot2_json rounded is stored separately; we also accept suggestions normalised in cand path
         s2full = ver.get("spot2_json") or {}
         # Check TP and invalid rounded to 2 decimals in spot2_json
-        tps = [float((t.get("range") or [0])[0]) for t in (s2full.get("tp") or [])]
-        inv = float((s2full.get("rencana_jual_beli") or {}).get("invalid"))
+        tps = [float(t.get("price")) for t in (s2full.get("tp") or [])]
+        inv = float(s2full.get("invalid"))
         assert all(abs(x - round(x, 2)) < 1e-9 for x in tps)
         assert abs(inv - round(inv, 2)) < 1e-9
 
@@ -97,9 +104,9 @@ async def test_verify_llm_missing_entries_or_tp_rejected(monkeypatch):
 
     import json
     # ask_llm returns object without tp
-    bad1 = {"rencana_jual_beli": {"entries": [{"range": [100, 100], "weight": 1.0}]}}
+    bad1 = {"entries": [], "tp": [{"name": "TP1", "price": 110}]}
     # ask_llm returns object without entries
-    bad2 = {"tp": [{"name": "TP1", "range": [110, 110]}]}
+    bad2 = {"entries": [{"price": 100, "weight": 1.0}], "tp": []}
 
     async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
         # Auth
@@ -112,7 +119,11 @@ async def test_verify_llm_missing_entries_or_tp_rejected(monkeypatch):
         aid = r.json()["id"]
 
         # Case 1: missing tp
-        monkeypatch.setattr(r_analyses, "ask_llm", lambda prompt: (json.dumps(bad1), {"prompt_tokens": 1, "completion_tokens": 1}), raising=True)
+        calls = [
+            (json.dumps(bad1), {"prompt_tokens": 1, "completion_tokens": 1}),
+            (json.dumps({"verdict": "confirm", "reasons": []}), {"prompt_tokens": 0, "completion_tokens": 0}),
+        ]
+        monkeypatch.setattr(r_analyses, "ask_llm", lambda prompt: calls.pop(0), raising=True)
         r = await client.post(f"/api/analyses/{aid}/verify", headers=H)
         assert r.status_code == 422
 
@@ -123,6 +134,10 @@ async def test_verify_llm_missing_entries_or_tp_rejected(monkeypatch):
         H2 = {"Authorization": f"Bearer {tok2}"}
         r = await client.post("/api/analyze", json={"symbol": "OPUSDT"}, headers=H2)
         aid2 = r.json()["id"]
-        monkeypatch.setattr(r_analyses, "ask_llm", lambda prompt: (json.dumps(bad2), {"prompt_tokens": 1, "completion_tokens": 1}), raising=True)
+        calls2 = [
+            (json.dumps(bad2), {"prompt_tokens": 1, "completion_tokens": 1}),
+            (json.dumps({"verdict": "confirm", "reasons": []}), {"prompt_tokens": 0, "completion_tokens": 0}),
+        ]
+        monkeypatch.setattr(r_analyses, "ask_llm", lambda prompt: calls2.pop(0), raising=True)
         r = await client.post(f"/api/analyses/{aid2}/verify", headers=H2)
         assert r.status_code == 422

--- a/auto-analisa-web/backend/app/workers/analyze_worker.py
+++ b/auto-analisa-web/backend/app/workers/analyze_worker.py
@@ -68,7 +68,7 @@ async def run_analysis(db: AsyncSession, user: User, symbol: str, trade_type: st
     score = score_symbol(feat)
     plan = await build_plan_async(db, bundle, feat, score, "auto")
     try:
-        spot2 = await build_spot2_from_plan(db, sym, plan)
+        spot2 = await build_spot2_from_plan(db, sym, plan, bundle=bundle)
         plan["spot2"] = spot2
     except Exception:
         pass
@@ -128,7 +128,7 @@ async def refresh_analysis_rules_only(db: AsyncSession, user: User, analysis: An
     score = score_symbol(feat)
     plan = await build_plan_async(db, bundle, feat, score, "auto")
     try:
-        spot2 = await build_spot2_from_plan(db, sym, plan)
+        spot2 = await build_spot2_from_plan(db, sym, plan, bundle=bundle)
         plan["spot2"] = spot2
     except Exception:
         pass

--- a/auto-analisa-web/frontend/src/app/(components)/PlanCard.tsx
+++ b/auto-analisa-web/frontend/src/app/(components)/PlanCard.tsx
@@ -57,10 +57,11 @@ export default function PlanCard({plan, onUpdate, llmEnabled, llmRemaining, onAf
   const invalids = useMemo(()=>{
     const s2 = p?.spot2 || {}
     const invs = s2?.invalids || {}
+    const invMain = typeof s2?.invalid === 'number'? s2.invalid : (typeof p?.invalid==='number'? p.invalid : undefined)
     return {
       m5:  typeof invs.m5 === 'number'  ? invs.m5  : (typeof p?.invalid_tactical_5m==='number'? p.invalid_tactical_5m : undefined),
       m15: typeof invs.m15 === 'number' ? invs.m15 : (typeof p?.invalid_soft_15m==='number'? p.invalid_soft_15m : undefined),
-      h1:  typeof invs.h1 === 'number'  ? invs.h1  : (typeof p?.invalid_hard_1h==='number'? p.invalid_hard_1h : (typeof p?.invalid==='number'? p.invalid : undefined)),
+      h1:  typeof invs.h1 === 'number'  ? invs.h1  : (typeof p?.invalid_hard_1h==='number'? p.invalid_hard_1h : invMain),
       h4:  typeof invs.h4 === 'number'  ? invs.h4  : (typeof p?.invalid_struct_4h==='number'? p.invalid_struct_4h : undefined),
     }
   },[p])

--- a/auto-analisa-web/frontend/src/app/(components)/Spot2View.tsx
+++ b/auto-analisa-web/frontend/src/app/(components)/Spot2View.tsx
@@ -1,15 +1,25 @@
 "use client"
 export default function Spot2View({ spot2, decimals, fmt:fmtProp }:{ spot2:any, decimals?:number, fmt?:(n:number)=>string|number }){
   if(!spot2) return null
-  const rjb = spot2.rencana_jual_beli || {}
-  const tp = spot2.tp || []
+  const entries = Array.isArray(spot2.entries) ? spot2.entries : []
+  const tp = Array.isArray(spot2.tp) ? spot2.tp : []
   const sr = spot2.sr || {}
   const m = spot2.metrics || {}
+  const macro = spot2.macro_gate || {}
+  const buyback = Array.isArray(spot2.buyback) ? spot2.buyback : []
+  const notes = Array.isArray(spot2.notes) ? spot2.notes : []
+  const warnings = Array.isArray(spot2.warnings) ? spot2.warnings : []
   const dec = typeof decimals==='number' ? decimals : (typeof m.price_decimals==='number'? m.price_decimals : 5)
   const fmt = (n:number)=> typeof fmtProp==='function' ? fmtProp(n) : (typeof n==='number'? n.toFixed(dec): n as any)
   const joinFmt = (arr:any[])=> (arr||[]).map((x:any)=> typeof x==='number'? fmt(x): x).join(' – ')
   return (
     <section className="rounded-xl ring-1 ring-zinc-200 dark:ring-white/10 bg-white/5 p-3 text-sm">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-500 mb-1">
+        <span className="px-2 py-0.5 rounded bg-cyan-600/10 text-cyan-700 dark:text-cyan-300">{spot2.trade_type?.toUpperCase?.() || 'SPOT'}</span>
+        {spot2.regime?.regime && <span>Regime: {spot2.regime.regime} ({typeof spot2.regime.confidence==='number'? (spot2.regime.confidence*100).toFixed(0):'-'}%)</span>}
+        {spot2.mode && <span>Mode: {spot2.mode}</span>}
+        {typeof m.macro_score==='number' && <span>Macro Score: {m.macro_score?.toFixed?.(1)} / {m.macro_score_threshold ?? '-'}</span>}
+      </div>
       {spot2.ringkas_teknis && (
         <div className="mb-2">
           <div className="text-zinc-500">Ringkas Teknis</div>
@@ -18,20 +28,30 @@ export default function Spot2View({ spot2, decimals, fmt:fmtProp }:{ spot2:any, 
       )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div>
-          <div className="text-zinc-500">Rencana Jual–Beli ({rjb.profile||'-'})</div>
+          <div className="text-zinc-500">Entries ({spot2.mode||'-'})</div>
           <ul className="list-disc pl-5">
-            {(rjb.entries||[]).map((e:any,i:number)=> (
-              <li key={i}>Range: {joinFmt(e.range||[])} • w={e.weight} • {e.type||'PB'}</li>
+            {entries.map((e:any,i:number)=> (
+              <li key={i} className="space-y-0.5">
+                <div>Harga: {typeof e.price==='number'? fmt(e.price): joinFmt(e.range||[])} • w={e.weight ?? '-'} • {e.type||spot2.mode||'PB'}</div>
+                {e.note && <div className="text-xs text-zinc-500">{e.note}</div>}
+              </li>
             ))}
+            {entries.length===0 && <li>Tidak ada entry.</li>}
           </ul>
         </div>
         <div>
           <div className="text-zinc-500">Invalid</div>
-          <div className="text-rose-500 font-medium">{typeof rjb.invalid==='number'? fmt(rjb.invalid): rjb.invalid}</div>
+          <div className="text-rose-500 font-medium">{typeof spot2.invalid==='number'? fmt(spot2.invalid): spot2.invalid ?? '-'}</div>
         </div>
         <div className="md:col-span-2">
           <div className="text-zinc-500">TP</div>
-          <div className="text-emerald-600">{tp.map((t:any)=> `${t.name||''}: ${joinFmt(t.range||[])}`).join(' • ')}</div>
+          <ul className="list-disc pl-5 text-emerald-600">
+            {tp.map((t:any,i:number)=> (
+              <li key={i}>
+                {t.name||`TP${i+1}`}: {typeof t.price==='number'? fmt(t.price): joinFmt(t.range||[])} • {t.qty_pct ?? '-'}% — {t.logic||'-'}
+              </li>
+            ))}
+          </ul>
         </div>
         <div>
           <div className="text-zinc-500">Support</div>
@@ -45,11 +65,55 @@ export default function Spot2View({ spot2, decimals, fmt:fmtProp }:{ spot2:any, 
           <div className="text-zinc-500">RR Min</div>
           <div className="text-cyan-600">{typeof m.rr_min==='number'? m.rr_min.toFixed(2):'-'}</div>
         </div>
+        {spot2.trailing && (
+          <div>
+            <div className="text-zinc-500">Trailing</div>
+            <div>{spot2.trailing.enabled? `Aktif (${spot2.trailing.anchor||'-'}, offset ${spot2.trailing.offset_atr ?? '-' }×ATR)` : 'Nonaktif'}</div>
+          </div>
+        )}
+        {spot2.time_exit && (
+          <div>
+            <div className="text-zinc-500">Time Exit</div>
+            <div>{spot2.time_exit.enabled? `${spot2.time_exit.ttl_min||'-'} menit • ${spot2.time_exit.reason||'-'}`:'Nonaktif'}</div>
+          </div>
+        )}
       </div>
-      {spot2.fail_safe && spot2.fail_safe.length>0 && (
-        <div className="mt-2">
-          <div className="text-zinc-500">Fail-safe</div>
-          <ul className="list-disc pl-5">{spot2.fail_safe.map((f:string,i:number)=> <li key={i}>{f}</li>)}</ul>
+      {buyback.length>0 && (
+        <div className="mt-3">
+          <div className="text-zinc-500">Buyback</div>
+          <ul className="list-disc pl-5">
+            {buyback.map((bb:any,i:number)=> (
+              <li key={i}>{bb.name||`BB${i+1}`}: {joinFmt(bb.range||[])} — {bb.note||'-'}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {macro && (
+        <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <div className="text-zinc-500">Window Hijau (WIB)</div>
+            <div>{(macro.prefer_wib||[]).join(', ')||'-'}</div>
+          </div>
+          <div>
+            <div className="text-zinc-500">Hindari (WIB)</div>
+            <div>{(macro.avoid_wib||[]).join(', ')||'-'}</div>
+          </div>
+          <div className="md:col-span-2">
+            <div className="text-zinc-500">Catatan Sesi</div>
+            <div>{macro.session_refs || '-'}</div>
+          </div>
+        </div>
+      )}
+      {notes.length>0 && (
+        <div className="mt-3">
+          <div className="text-zinc-500">Catatan Eksekusi</div>
+          <ul className="list-disc pl-5">{notes.map((n:string,i:number)=> <li key={i}>{n}</li>)}</ul>
+        </div>
+      )}
+      {warnings.length>0 && (
+        <div className="mt-3">
+          <div className="text-rose-500">Peringatan</div>
+          <ul className="list-disc pl-5 text-rose-500/80">{warnings.map((w:string,i:number)=> <li key={i}>{w}</li>)}</ul>
         </div>
       )}
     </section>


### PR DESCRIPTION
## Ringkasan
- membangun ulang generator plan spot agar langsung menghasilkan skema SPOT-II+ dengan ladder TP ≥3, trailing hybrid, time exit, buyback, dan filter makro berbasis jendela WIB/WITA
- memperbarui alur verifikasi LLM menjadi dua tahap (Tuner + Verifikator), menyesuaikan validator, pembulatan harga, serta strategi supaya mendukung struktur baru dan integrasi skor makro
- memodernisasi komponen FE (Spot2View, PlanCard, LLMReport) serta serangkaian pengujian untuk memastikan skema baru tervalidasi dan dibulatkan sesuai aturan

## Uji
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08f7b41208328bea902e17bce3bd5